### PR TITLE
some error-handling for endpoints, reformat of /filtersyslog, +

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 tags
 **/.idea/workspace.xml
 **/.idea/tasks.xml
+**.idea


### PR DESCRIPTION
- error-handling for logadaption, checks if the sent parameters' set of keys is a subset of allowed keys
- db error-handling for /filtersyslog, /syslog and /logadaption.
- reformat of /filtersyslog to make it more readable
- changed from read-string -> parseInt to allow input starting with 000

#87 
#97 