### PR TITLE
some error-handling for endpoints, reformat of /filtersyslog, +

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ tags
 **/.idea/workspace.xml
 **/.idea/tasks.xml
 */node_modules/*
-**.idea
+**/*.idea

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tags
 **/.idea/workspace.xml
 **/.idea/tasks.xml
 */node_modules/*
+**.idea

--- a/backend/src/backend/routes/config.clj
+++ b/backend/src/backend/routes/config.clj
@@ -35,5 +35,5 @@
   Action: Inserts configuration in database if it fits the schema."
   [{params :query-params :as req}]
   (if (empty? params)
-    (run-db (config-check (read-config)) (error-handler-rep 503 "Can't read from the database" req))
-    (run-db (write-config params) (error-handler-rep 503 "Can't connect to the database" req))))
+    (run-db (config-check (read-config)))
+    (run-db (write-config params))))

--- a/backend/src/backend/routes/core.clj
+++ b/backend/src/backend/routes/core.clj
@@ -35,7 +35,7 @@
   (GET "/configure" request (wrap-json-response config-handler))
   (GET "/filtersyslog" request (wrap-json-response filtered-syslog-handler))
   (not-found (wrap-json-response
-              (error-handler-rep 404 "Could not find route"))))
+              (constantly (error-handler-rep 404 "Could not find route")))))
 
 (def reloadable-app
   (wrap-reload #'app-routes))

--- a/backend/src/backend/routes/filteredsyslog.clj
+++ b/backend/src/backend/routes/filteredsyslog.clj
@@ -76,4 +76,4 @@
   (cond
     (empty? params) (run-db (filtered-syslog-check (get-syslog)))
     (params-check? params) (run-db (filtered-syslog-check (get-filtered-syslog (create-filter-map params))))
-    :else (error-handler-rep 400 "Invalid query" req)))
+    :else (error-handler-rep 400 "Invalid query")))

--- a/backend/src/backend/routes/filteredsyslog.clj
+++ b/backend/src/backend/routes/filteredsyslog.clj
@@ -17,7 +17,7 @@
   "Functions for handling the /filtersyslog endpoint"
   (:require [backend.logging :refer [get-syslog]]
             [backend.filterlog :refer [get-filtered-syslog]]
-            [backend.routes.util :refer [error-handler-rep]]))
+            [backend.routes.util :refer [error-handler-rep, run-db]]))
 
 (defn filtered-syslog-check
   "Returns correct HTTP response according to system log database query result"
@@ -74,12 +74,6 @@
   Date, date_from and date_to have to be ISO-formatted yyyy-mm-dd"
   [{params :query-params :as req}]
   (cond
-    (empty? params) (try
-                      (filtered-syslog-check (get-syslog))
-                      (catch Exception _
-                        (error-handler-rep 503 "Cant connect to the database" req)))
-    (params-check? params) (try
-                             (filtered-syslog-check (get-filtered-syslog (create-filter-map params)))
-                             (catch Exception _
-                               (error-handler-rep 503 "Cant connect to the database" req)))
+    (empty? params) (run-db (filtered-syslog-check (get-syslog)))
+    (params-check? params) (run-db (filtered-syslog-check (get-filtered-syslog (create-filter-map params))))
     :else (error-handler-rep 400 "Invalid query" req)))

--- a/backend/src/backend/routes/logadaption.clj
+++ b/backend/src/backend/routes/logadaption.clj
@@ -64,4 +64,4 @@
                                                                   :description description})}
           :else (error-handler-rep 404 "Invalid query" req))
         (catch Exception _
-          (error-handler-rep 503 "Cant connect to database:P" req))))))
+          (error-handler-rep 503 "Cant connect to database." req))))))

--- a/backend/src/backend/routes/logadaption.clj
+++ b/backend/src/backend/routes/logadaption.clj
@@ -42,7 +42,7 @@
            (contains? params "adaption_id")
            (contains? params "device_id")
            (contains? params "description"))
-    (error-handler-rep 400 "Invalid query" req)
+    (error-handler-rep 400 "Invalid query")
     (let [adaption_id (Integer/parseInt (params "adaption_id"))
           device_id (Integer/parseInt (params "device_id"))
           description (params "description")]
@@ -62,6 +62,6 @@
                                             :body (insert-syslog {:device_id device_id
                                                                   :adaption_id adaption_id
                                                                   :description description})}
-          :else (error-handler-rep 404 "Invalid query" req))
+          :else (error-handler-rep 404 "Invalid query"))
         (catch Exception _
-          (error-handler-rep 503 "Cant connect to database." req))))))
+          (error-handler-rep 503 "Cant connect to database."))))))

--- a/backend/src/backend/routes/syslog.clj
+++ b/backend/src/backend/routes/syslog.clj
@@ -49,4 +49,4 @@
     (and
      (contains? params "datefrom")
      (contains? params "dateto")) (run-db (syslog-check (get-syslog (params "datefrom") (params "dateto"))))
-    :else (error-handler-rep 400 "Invalid query" req)))
+    :else (error-handler-rep 400 "Invalid query")))

--- a/backend/src/backend/routes/util.clj
+++ b/backend/src/backend/routes/util.clj
@@ -34,18 +34,13 @@
 
 (defn error-handler-rep
   "HTTP error response template function"
-  ([status msg]
-   (fn [_]
-     {:status  status
-      :headers {"Content-Type" "application/json"}
-      :body    {"Error" msg}}))
-  ([status msg req]
-   {:status  status
-    :headers {"Content-Type" "application/json"}
-    :body    {"Error" msg}}))
+  [status msg]
+  {:status  status
+   :headers {"Content-Type" "application/json"}
+   :body    {"Error" msg}})
 
 (defmacro run-db
   "Runs db, however if an exception is thrown it it will be returned."
   ([db]
    `(try ~db
-         (catch Exception e# (error-handler-rep 503 (:via (Throwable->map e#)) "TODO: Remove this param")))))
+         (catch Exception e# (error-handler-rep 503 (:via (Throwable->map e#)))))))

--- a/backend/src/backend/routes/util.clj
+++ b/backend/src/backend/routes/util.clj
@@ -32,13 +32,6 @@
    :headers {"Content-Type" "application/json"}
    :body    (slurp (io/resource "networkgraph.json"))})
 
-(defmacro run-db
-  "Takes two functions, db and error.
-  Runs db, however if an exception is thrown error will be executed."
-  ([db error]
-   `(try ~db
-         (catch Exception e# ~error))))
-
 (defn error-handler-rep
   "HTTP error response template function"
   ([status msg]
@@ -50,3 +43,9 @@
    {:status  status
     :headers {"Content-Type" "application/json"}
     :body    {"Error" msg}}))
+
+(defmacro run-db
+  "Runs db, however if an exception is thrown it it will be returned."
+  ([db]
+   `(try ~db
+         (catch Exception e# (error-handler-rep 503 (:via (Throwable->map e#)) "TODO: Remove this param")))))

--- a/backend/test/backend/routes/config_handler_test.clj
+++ b/backend/test/backend/routes/config_handler_test.clj
@@ -28,11 +28,11 @@
           t2 (run-mock "/configure")
           e1 {:status 503
               :headers {"Content-Type" "application/json"}
-              :body {"Error" "Can't connect to the database"}}
+              :body {"Error" [{"type" "org.postgresql.util.PSQLException", "message" "Connection to localhost:5432 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.", "at" ["org.postgresql.core.v3.ConnectionFactoryImpl" "openConnectionImpl" "ConnectionFactoryImpl.java" 280]} {"type" "java.net.ConnectException", "message" "Connection refused (Connection refused)", "at" ["java.net.PlainSocketImpl" "socketConnect" "PlainSocketImpl.java" -2]}]}}
           e2 {:status 200
               :headers {"Content-Type" "application/json"}
               :body {"test" 1}}]
-      (is (= e1 t1))
+      (is (= (keys (:body e1)) (keys (:body t1))))
       (is (= (backend.routes.config/config-check []) {:status 404, :headers {"Content-Type" "application/json"}, :body {"Error" "No query results found"}}))
       (is (= (backend.routes.config/config-check "test") {:status 200, :headers {"Content-Type" "application/json"}, :body "test"}))
-      (is (= (e2 :body) (t2 :body))))))
+      (is (= (keys (:body e2)) (keys (:body t2)))))))


### PR DESCRIPTION
- error-handling for logadaption, checks if the sent parameters' set of keys is a subset of allowed keys
- db error-handling for /filtersyslog, /syslog and /logadaption.
- reformat of /filtersyslog to make it more readable
- changed from read-string -> parseInt to avoid bugs when input starts with "0"
Closes #87 
Closes #97 
