### PR TITLE
138 fix config

### DIFF
--- a/backend/doc/intro.md
+++ b/backend/doc/intro.md
@@ -43,8 +43,8 @@ The JSON response has the following scructure:
 | GET | None | None | None |
 |-----|------|------|------|
 
-Endpoint for retrieving the servers configuration file. Amongst other things this file
-contains information about what the set data source is.
+Endpoint for retrieving the latest configuration row in the config table. Config table
+contains configuration parameters for the OKSE message broker.
 
 | POST | None | JSON | application/json |
 |------|------|------|------------------|
@@ -54,6 +54,13 @@ a JSON body which can contain any number of OKSE parameters, the only required p
 is a `device_id`. When the row as been inserted the endpoint will return the entire row
 in response as a JSON object.
 
+### /serverconfig
+
+| GET | None | None | None |
+|-----|------|------|------|
+
+Endpoint for retrieving the servers configuration file. Amongst other things this file
+contains information about what the set data source is.
 
 ### /filtersyslog
 

--- a/backend/src/backend/core.clj
+++ b/backend/src/backend/core.clj
@@ -20,7 +20,8 @@
             [postgre-types.json :refer [add-jsonb-type]]
             [aero.core :refer (read-config)]
             [backend.routes.core :refer [reloadable-app]]
-            [backend.database])
+            [backend.database]
+            [backend.server-config :as backend.server-config])
   (:gen-class))
 
 (def cli-options
@@ -44,6 +45,7 @@
     (let [temp-cfg (read-config (get-in opt [:options :config]))]
       ;; Add support for Postgres JSONB
       (add-jsonb-type clojure.data.json/write-str clojure.data.json/read-str)
+      (swap! backend.server-config/server-config (constantly temp-cfg))
       (intern 'backend.database 'cfg temp-cfg)
       (run-jetty (ring-params/wrap-params reloadable-app) (get temp-cfg :webserver))
       (println "Server started on port" (get-in temp-cfg [:webserver :port])))))

--- a/backend/src/backend/routes/config.clj
+++ b/backend/src/backend/routes/config.clj
@@ -16,7 +16,8 @@
 (ns backend.routes.config
   (:require [aero.core :as ac]
             [backend.configuration :refer [write-config, read-config]]
-            [backend.routes.util :refer [error-handler-rep, run-db]]))
+            [backend.routes.util :refer [error-handler-rep, run-db]]
+            [backend.server-config :refer [server-config]]))
 
 (defn config-check
   "Returns correct HTTP response according to configuration result"
@@ -57,10 +58,9 @@
 (defn server-config-handler
   "HTTP GET handler for exposing the server configuration file"
   [req]
-  (let [cfg (ac/read-config "config.edn")]
-    (if-not cfg
+  (let [config @server-config]
+    (if-not config
       (error-handler-rep 500 "Cannot retrieve server configuration file")
       {:status 200
        :header {"Content-Type" "application-json"}
-       :body cfg})))
-
+       :body config})))

--- a/backend/src/backend/server_config.clj
+++ b/backend/src/backend/server_config.clj
@@ -1,0 +1,3 @@
+(ns backend.server-config)
+
+(def server-config (atom nil))


### PR DESCRIPTION
Backend now serves the correct configuration file even if a user supplies their own configuration file. Closes #138 